### PR TITLE
게시판 API 만들기 - Data REST 적용 및 테스트 정의

### DIFF
--- a/board-project/build.gradle
+++ b/board-project/build.gradle
@@ -27,6 +27,8 @@ dependencies {
     annotationProcessor 'org.projectlombok:lombok'
     runtimeOnly 'com.h2database:h2'
     runtimeOnly 'com.mysql:mysql-connector-j'
+    implementation 'org.springframework.boot:spring-boot-starter-data-rest'
+    implementation 'org.springframework.data:spring-data-rest-hal-explorer'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
 }
 

--- a/board-project/src/main/java/com/yoondev/boardproject/repository/ArticleCommentRepository.java
+++ b/board-project/src/main/java/com/yoondev/boardproject/repository/ArticleCommentRepository.java
@@ -2,7 +2,9 @@ package com.yoondev.boardproject.repository;
 
 import com.yoondev.boardproject.domain.ArticleComment;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.rest.core.annotation.RepositoryRestResource;
 
+@RepositoryRestResource
 public interface ArticleCommentRepository extends JpaRepository<ArticleComment, Long> {
 
 }

--- a/board-project/src/main/java/com/yoondev/boardproject/repository/ArticleRepository.java
+++ b/board-project/src/main/java/com/yoondev/boardproject/repository/ArticleRepository.java
@@ -2,6 +2,9 @@ package com.yoondev.boardproject.repository;
 
 import com.yoondev.boardproject.domain.Article;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.rest.core.annotation.RepositoryRestResource;
+
+@RepositoryRestResource
 
 public interface ArticleRepository extends JpaRepository<Article, Long> {
 }

--- a/board-project/src/main/resources/application.yaml
+++ b/board-project/src/main/resources/application.yaml
@@ -25,7 +25,9 @@ spring:
       hibernate.default_batch_fetch_size: 100
 #  h2.console.enabled: false
   sql.init.mode: always
-
+  data.rest:
+    base-path: /api
+    detection-strategy: annotated
 
 ---
 # 테스트 DB 사용시 설정

--- a/board-project/src/test/java/com/yoondev/boardproject/controller/DataRestTest.java
+++ b/board-project/src/test/java/com/yoondev/boardproject/controller/DataRestTest.java
@@ -1,0 +1,89 @@
+package com.yoondev.boardproject.controller;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+import  static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@DisplayName("Data REST - API Test")
+@Transactional
+@AutoConfigureMockMvc
+@SpringBootTest
+public class DataRestTest {
+    private final MockMvc mvc;
+
+    public DataRestTest(@Autowired MockMvc mvc) {
+        this.mvc = mvc;
+    }
+
+    @DisplayName("[api] 게시글 리스트 조회")
+    @Test
+    void givenNothing_whenRequestingArticles_thenReturnArticlesJsonResponse() throws Exception {
+        // Given
+
+        // When & Then
+        mvc.perform(get("/api/articles"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.valueOf("application/hal+json")))
+                .andDo(print());
+
+    }
+    @DisplayName("[api] 게시글 단건 조회")
+    @Test
+    void given1_whenRequestingArticle_thenReturnArticleJsonResponse() throws Exception {
+        // Given
+
+        // When & Then
+        mvc.perform(get("/api/articles/1"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.valueOf("application/hal+json")))
+                .andDo(print());
+
+    }
+    @DisplayName("[api] 게시글 댓글 리스트 조회")
+    @Test
+    void given1_whenRequestingArticleCommentsFromArticle_thenReturnArticleCommentsJsonResponse() throws Exception {
+        // Given
+
+        // When & Then
+        mvc.perform(get("/api/articles/1/articleComments"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.valueOf("application/hal+json")))
+                .andDo(print());
+
+    }
+    @DisplayName("[api] 댓글 리스트 조회")
+    @Test
+    void given1_whenRequestingArticleComments_thenReturnArticleCommentsJsonResponse() throws Exception {
+        // Given
+
+        // When & Then
+        mvc.perform(get("/api/articleComments"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.valueOf("application/hal+json")))
+                .andDo(print());
+
+    }
+    @DisplayName("[api] 댓글 단건 조회")
+    @Test
+    void given1_whenRequestingArticleComment_thenReturnArticleCommentsJsonResponse() throws Exception {
+        // Given
+
+        // When & Then
+        mvc.perform(get("/api/articleComments/1"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.valueOf("application/hal+json")))
+                .andDo(print());
+
+    }
+}


### PR DESCRIPTION
게시글, 댓글 데이터는 Spring Data REST로 서비스하고, 해당 API들의 존재여부만 확인하도록 통합테스트 작성